### PR TITLE
Profile: Show natural width and height of avatars

### DIFF
--- a/spacialgaze-plugins/profile.js
+++ b/spacialgaze-plugins/profile.js
@@ -305,7 +305,7 @@ exports.commands = {
 			Economy.readMoney(toId(username), currency => {
 				let profile = '';
 				profile += showBadges(toId(username));
-				profile += '<img src="' + avatar + '" height="80" width="80" align="left">';
+				profile += '<img src="' + avatar + '" align="left">';
 				if (!getFlag(toId(username))) {
 					profile += '&nbsp;<font color="#24678d"><b>Name:</b></font> ' + SG.nameColor(username, true) + ' ' + titleCheck(username) + '<br />';
 				} else {


### PR DESCRIPTION
Sometimes user cards and battle rooms show proper avatar but in profile it gets kinda weird example user:- Ashley The Pikachu
