### PR TITLE
Tweaked MetalGreymons Stats very Slightly

### DIFF
--- a/mods/digimon/pokedex.js
+++ b/mods/digimon/pokedex.js
@@ -953,12 +953,12 @@ exports.BattlePokedex = {
 		digimon: "MetalGreymon",
 		types: ["Mech", "Fire", "Battle"],
 		baseStats: {
-			hp: 222,
+			hp: 220,
 			atk: 136,
 			def: 117,
 			spa: 136,
 			spd: 117,
-			spe: 100,
+			spe: 102,
 		},
 		abilities: {
 			0: "Virus",


### PR DESCRIPTION
I removed 2 hp points and put the 2 points into speed, this is so the stats are not identical to the vaccine version which will be coded later.