### PR TITLE
Begin fixing deprecation warnings for asynchronous...

### DIFF
--- a/spacialgaze-plugins/SG.js
+++ b/spacialgaze-plugins/SG.js
@@ -92,7 +92,7 @@ SG.reloadCSS = function () {
 		path: '/customcss.php?server=' + (Config.serverid || cssPath),
 		method: 'GET',
 	};
-	http.get(options);
+	http.get(options, () => Monitor.adminlog("Successfully reloaded the server CSS."));
 };
 
 //Daily Rewards System for SpacialGaze by Lord Haji

--- a/spacialgaze-plugins/SG.js
+++ b/spacialgaze-plugins/SG.js
@@ -92,7 +92,7 @@ SG.reloadCSS = function () {
 		path: '/customcss.php?server=' + (Config.serverid || cssPath),
 		method: 'GET',
 	};
-	http.get(options, () => Monitor.adminlog("Successfully reloaded the server CSS."));
+	http.get(options, () => {});
 };
 
 //Daily Rewards System for SpacialGaze by Lord Haji

--- a/spacialgaze-plugins/eShop.js
+++ b/spacialgaze-plugins/eShop.js
@@ -23,7 +23,7 @@ function NewItem(name, desc, price, isSSB) {
 
 function writeShop() {
 	if (!writeJSON) return false; //Prevent corruptions
-	fs.writeFile('config/eShop.json', JSON.stringify(SG.eShop));
+	fs.writeFile('config/eShop.json', JSON.stringify(SG.eShop), () => {});
 }
 
 function shopDisplay() {

--- a/spacialgaze-plugins/economy.js
+++ b/spacialgaze-plugins/economy.js
@@ -72,7 +72,7 @@ let Economy = global.Economy = {
 
 	logDice: function (message) {
 		if (!message) return false;
-		fs.appendFile('logs/dice.log', '[' + new Date().toUTCString() + '] ' + message + '\n');
+		fs.appendFile('logs/dice.log', '[' + new Date().toUTCString() + '] ' + message + '\n', () => {});
 	},
 };
 

--- a/spacialgaze-plugins/ssb.js
+++ b/spacialgaze-plugins/ssb.js
@@ -1,4 +1,4 @@
-'use strict';
+﻿'use strict';
 
 let fs = require('fs');
 let ssbWrite = true; //if false, do not write to json
@@ -9,7 +9,7 @@ let typeList = ['Normal', 'Fire', 'Water', 'Grass', 'Electric', 'Ice', 'Fighting
 
 global.writeSSB = function () {
 	if (!ssbWrite) return false; //Prevent corruptions
-	fs.writeFile('config/ssb.json', JSON.stringify(SG.ssb));
+	fs.writeFile('config/ssb.json', JSON.stringify(SG.ssb), () => {});
 };
 
 //Shamlessly ripped from teambuilder client.

--- a/spacialgaze-plugins/vouchers.js
+++ b/spacialgaze-plugins/vouchers.js
@@ -98,7 +98,7 @@ class Voucher {
 
 function writeFile() {
 	if (!writeJSON) return false; //Prevent corruptions
-	fs.writeFile('config/vouchers.json', JSON.stringify(SG.vouchers));
+	fs.writeFile('config/vouchers.json', JSON.stringify(SG.vouchers), () => {});
 }
 
 //load JSON


### PR DESCRIPTION
...methods without a callback. They now require a callback in order to avoid the deprecation warning, simply because a callback *should* be passed in order to access the data we're trying to load. This has mostly occurred within trying to write to a file using the asynchronous `fs.writeFile`, rather than the `fs.writeFileSync`. I decided to just input a noop so that they still function asynchronously.